### PR TITLE
Skipped test were causing tests suite to hang and timeout

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -52,14 +52,12 @@ module.exports = function(wct, pluginOptions) {
   }.bind(this));
 
   wct.on('sub-suite-end', function(browser, sharedState, stats) {
-    console.log('sub-suite-end');
     collection.att('passed', stats.passing);
     collection.att('failed', stats.failing);
     collection.att('skipped', stats.pending);
   }.bind(this));
 
   wct.on('test-start', function(browser, test) {
-    console.log('test-start');
     var meta = getTestMeta(browser, test);
     currentTest = collection.ele('test');
     currentTest.att('name', meta.name);

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -17,17 +17,17 @@ function getTestMeta(browser, test) {
 
 function getDate() {
   now = new Date();
-  year = "" + now.getFullYear();
-  month = "" + (now.getMonth() + 1); if (month.length == 1) { month = "0" + month; }
-  day = "" + now.getDate(); if (day.length == 1) { day = "0" + day; }
+  var year = "" + now.getFullYear();
+  var month = "" + (now.getMonth() + 1); if (month.length == 1) { month = "0" + month; }
+  var day = "" + now.getDate(); if (day.length == 1) { day = "0" + day; }
   return year + "-" + month + "-" + day;
 }
 
 function getTime() {
   now = new Date();
-  hour = "" + now.getHours(); if (hour.length == 1) { hour = "0" + hour; }
-  minute = "" + now.getMinutes(); if (minute.length == 1) { minute = "0" + minute; }
-  second = "" + now.getSeconds(); if (second.length == 1) { second = "0" + second; }
+  var hour = "" + now.getHours(); if (hour.length == 1) { hour = "0" + hour; }
+  var minute = "" + now.getMinutes(); if (minute.length == 1) { minute = "0" + minute; }
+  var second = "" + now.getSeconds(); if (second.length == 1) { second = "0" + second; }
   return hour + ":" + minute + ":" + second;
 }
 
@@ -57,16 +57,13 @@ module.exports = function(wct, pluginOptions) {
     collection.att('skipped', stats.pending);
   }.bind(this));
 
-  wct.on('test-start', function(browser, test) {
+  wct.on('test-end', function(browser, test) {
     var meta = getTestMeta(browser, test);
     currentTest = collection.ele('test');
     currentTest.att('name', meta.name);
     currentTest.att('method', meta.method);
     currentTest.att('type', meta.type);
-  }.bind(this));
 
-  wct.on('test-end', function(browser, test) {
-    currentTest = currentTest || collection.ele('test');
     if(test.state === 'pending') {
       currentTest.att('result', 'Skip');
       return;

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -52,12 +52,14 @@ module.exports = function(wct, pluginOptions) {
   }.bind(this));
 
   wct.on('sub-suite-end', function(browser, sharedState, stats) {
+    console.log('sub-suite-end');
     collection.att('passed', stats.passing);
     collection.att('failed', stats.failing);
     collection.att('skipped', stats.pending);
   }.bind(this));
 
   wct.on('test-start', function(browser, test) {
+    console.log('test-start');
     var meta = getTestMeta(browser, test);
     currentTest = collection.ele('test');
     currentTest.att('name', meta.name);
@@ -66,8 +68,10 @@ module.exports = function(wct, pluginOptions) {
   }.bind(this));
 
   wct.on('test-end', function(browser, test) {
+    currentTest = currentTest || collection.ele('test');
     if(test.state === 'pending') {
-        currentTest.att('result', 'Skip');
+      currentTest.att('result', 'Skip');
+      return;
     } else if(test.state === 'failing') {
       currentTest.att('result', 'Fail');
       var fail = currentTest.ele('failure');

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -35,7 +35,6 @@ module.exports = function(wct, pluginOptions) {
   var xml = xmlbuilder.create('assemblies', {version: '1.0', encoding: 'UTF-8'});
   var assembly;
   var collection;
-  var currentTest;
 
   wct.on('browser-start', function(browser, data, stats) {
     assembly = xml.ele('assembly', {
@@ -59,7 +58,7 @@ module.exports = function(wct, pluginOptions) {
 
   wct.on('test-end', function(browser, test) {
     var meta = getTestMeta(browser, test);
-    currentTest = collection.ele('test');
+    var currentTest = collection.ele('test');
     currentTest.att('name', meta.name);
     currentTest.att('method', meta.method);
     currentTest.att('type', meta.type);


### PR DESCRIPTION
I fixed it so skipped tests were properly reported.

The issue is that the 'test-start' is not called on a skip test therefore no currentTest variable is available, and there is no 'time' attribute for the current test. I fixed both issues on my fork if you are interested to bring them back into your plugin.

Hope it helps.
