### PR TITLE
Report using the suite structure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#wct-xunit-reporter
+# wct-xunit-reporter
 
-##Installing
+## Installing
 
 ```npm install wct-xunit-reporter ```
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -2,17 +2,21 @@ var fs = require('fs');
 var xmlbuilder = require('xmlbuilder');
 
 function getTestMeta(browser, test) {
-  var meta = {
-    'name': test.test[test.test.length -1],
-    'method': '',
+  return {
+    'name': test.test.slice(2).join(' > '),
+    'method': test.test.slice(1).join('.'),
     'type': test.test[0]
   };
-  var path = [];
-  for (i = 1; i < test.test.length; i++) {
-    path.push(test.test[i]);
-  }
-  meta.method = path.join('.');
-  return meta;
+}
+
+function updateStats(element, test) {
+  var item = element.item;
+  var stats = element.stats;
+  stats[test.state] = (stats[test.state] || 0) + 1;
+  item.att('total', (stats.passing + stats.failing + stats.pending));
+  item.att('passed', stats.passing);
+  item.att('failed', stats.failing);
+  item.att('skipped', stats.pending);
 }
 
 function getDate() {
@@ -33,32 +37,55 @@ function getTime() {
 
 module.exports = function(wct, pluginOptions) {
   var xml = xmlbuilder.create('assemblies', {version: '1.0', encoding: 'UTF-8'});
-  var assembly;
-  var collection;
+  var assemblies = {};
+
+  function getAssembly(test, browser) {
+    var name = test.test[0];
+    var assembly = assemblies[name];
+
+    if(!assembly) {
+      assembly = assemblies[name] = {
+        collections: {},
+        stats: {passing: 0, failing: 0, pending: 0},
+        item: xml.ele('assembly', {
+          name,
+          'environment': browser.browserName + '.' + browser.version,
+          'test-framework': 'web-component-tester',
+          'run-date': getDate(),
+          'run-time': getTime()
+        })
+      };
+    }
+    updateStats(assembly, test);
+    return assembly;
+  }
+
+  function getCollection(test, browser) {
+    var name = test.test[1];
+    var assembly = getAssembly(test, browser);
+    var collection = assembly.collections[name];
+    if(!collection) {
+      collection = assembly.collections[name] = {
+        item: assembly.item.ele('collection', {name}),
+        stats: {passing: 0, failing: 0, pending: 0},
+      };
+    }
+    updateStats(collection, test);
+    return collection;
+  }
 
   wct.on('browser-start', function(browser, data, stats) {
-    assembly = xml.ele('assembly', {
-      'name': 'WCT Unit tests [' + browser.browserName + '.' + browser.version + ']',
-      'environment': browser.browserName + '.' + browser.version,
-      'test-framework': 'web-component-tester',
-      'run-date': getDate(),
-      'run-time': getTime()
-    });
+    JSON.stringify(browser, data, stats);
   }.bind(this));
 
   wct.on('sub-suite-start', function(browser, sharedState, stats) {
-    collection = assembly.ele('collection');
-  }.bind(this));
-
-  wct.on('sub-suite-end', function(browser, sharedState, stats) {
-    collection.att('passed', stats.passing);
-    collection.att('failed', stats.failing);
-    collection.att('skipped', stats.pending);
+    JSON.stringify(browser, sharedState, stats);
   }.bind(this));
 
   wct.on('test-end', function(browser, test) {
     var meta = getTestMeta(browser, test);
-    var currentTest = collection.ele('test');
+    var collection = getCollection(test, browser);
+    var currentTest = collection.item.ele('test');
     currentTest.att('name', meta.name);
     currentTest.att('method', meta.method);
     currentTest.att('type', meta.type);
@@ -77,18 +104,6 @@ module.exports = function(wct, pluginOptions) {
       currentTest.att('result', 'Pass');
     }
     currentTest.att('time', test.duration);
-  }.bind(this));
-
-  wct.on('browser-end', function(browser, error, stats) {
-    assembly.att('total', (stats.passing + stats.failing + stats.pending));
-    assembly.att('passed', stats.passing);
-    assembly.att('failed', stats.failing);
-    assembly.att('skipped', stats.pending);
-    if (error) {
-      var errors = assembly.ele('errors');
-      var err = errors.ele('error');
-      err.dat(error);
-    }
   }.bind(this));
 
   wct.on('run-end', function(error) {


### PR DESCRIPTION
This uses the suite structure to make the assembly and collection element for the tests (instead of a single collection per assembly approach).

I understand the changes are quite deep, but as IMHO it looks like a better way to structure the xunit reports, I thought it was fair to attempt to contribute it back to the source. If this is not up to be merged do to the impact of changes, please let me know and I'll keep the fork opened.

+ fix Docs MD issues

Thanx!